### PR TITLE
bugfix: errors raised when installing on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='django-mailgun-validation',
-    version='1.0.1',
+    version='1.0.2',
     description='Django fields for validating email using the Mailgun API',
     author='Antonio Ognio',
     author_email='antonio@ognio.com',
@@ -10,7 +10,7 @@ setup(name='django-mailgun-validation',
         'mailgun_validation',
     ],
     package_dir={
-        'mailgun': 'mailgun_validation/',
+        'mailgun': 'mailgun_validation',
     },
     install_requires=[
         'requests',


### PR DESCRIPTION
raise ValueError, "path '%s' cannot end with '/'" % pathname
ValueError: path 'mailgun_validation/' cannot end with '/'